### PR TITLE
Feature/simplify proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+venv/
+.idea/

--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ nginx_vhosts:
           proxy_set_header       Connection          "upgrade";
           proxy_set_header        upgrade             $http_upgrade;
       - name: /api/websocket
-        proxy: "wws://"
+        proxy: "wss://"
         backend: automation/api/websocket
         extra_parameters: |
           proxy_http_version         1.1;

--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ nginx_vhosts:
           proxy_set_header       Connection          "upgrade";
           proxy_set_header        upgrade             $http_upgrade;
       - name: /api/websocket
-        proxy: True
+        proxy: "wws://"
         backend: automation/api/websocket
         extra_parameters: |
           proxy_http_version         1.1;

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ fail2ban_ssh_private_key:
 
 ## Role Variables
 
+**NOTE**  
+Any vhost's `location.proxy` will perform a reverse proxy if:  
+- `location.proxy` is `True`  
+- `lcoation.proxy` is a schema/protocol string (i.e. `https://`, `wss://`) - there is no validation on this field when a
+  string, it is your responsibility to ensure it is properly formatted for your use case.
+
 ### defaults/main.yml
 
 ```yaml

--- a/templates/default-ssl.conf.j2
+++ b/templates/default-ssl.conf.j2
@@ -26,9 +26,9 @@ server {
 {% if location.extra_parameters is defined and location.extra_parameters != None %}
         {{ location.extra_parameters|indent(8, False) }}
 {% endif %}
-{% if location.proxy is defined and location.proxy %}
+{% if (location.proxy | default(False)) is truthy %}
         include /etc/nginx/proxy.conf;
-        proxy_pass {{ location.proxypass_protocol }}{{ location.backend }};
+        proxy_pass {{ (location.proxy is string and location.proxy) or 'http://' }}{{ location.backend }};
 {% if location.custom_css is defined %}
         proxy_set_header Accept-Encoding "";
         sub_filter

--- a/templates/default-ssl.conf.j2
+++ b/templates/default-ssl.conf.j2
@@ -26,7 +26,7 @@ server {
 {% if location.extra_parameters is defined and location.extra_parameters != None %}
         {{ location.extra_parameters|indent(8, False) }}
 {% endif %}
-{% if (location.proxy | default(False)) is boolean or (location.proxy | default(False)) is string  %}
+{% if ((location.proxy | default(False) is sameas True)) or (location.proxy | default(False)) is string  %}
         include /etc/nginx/proxy.conf;
         proxy_pass {{ (location.proxy is string and location.proxy) or 'http://' }}{{ location.backend }};
 {% if location.custom_css is defined %}

--- a/templates/default-ssl.conf.j2
+++ b/templates/default-ssl.conf.j2
@@ -26,7 +26,7 @@ server {
 {% if location.extra_parameters is defined and location.extra_parameters != None %}
         {{ location.extra_parameters|indent(8, False) }}
 {% endif %}
-{% if (location.proxy | default(False)) is truthy %}
+{% if (location.proxy | default(False)) is boolean or (location.proxy | default(False)) is string  %}
         include /etc/nginx/proxy.conf;
         proxy_pass {{ (location.proxy is string and location.proxy) or 'http://' }}{{ location.backend }};
 {% if location.custom_css is defined %}

--- a/templates/default-ssl.conf.j2
+++ b/templates/default-ssl.conf.j2
@@ -26,9 +26,11 @@ server {
 {% if location.extra_parameters is defined and location.extra_parameters != None %}
         {{ location.extra_parameters|indent(8, False) }}
 {% endif %}
+{# If location.proxy === True or a non-empty string, proxy the request #}
 {% if ((location.proxy | default(False) is sameas True)) or (location.proxy | default(False)) is string  %}
         include /etc/nginx/proxy.conf;
-        proxy_pass {{ (location.proxy is string and location.proxy) or 'http://' }}{{ location.backend }};
+        {# If location.proxy is a string, it is assumed to be a properly formatted scheme/protocol, if it is True then default to 'http://' #}
+        proxy_pass {{ (location.proxy is string) | ternary(location.proxy, 'http://') }}{{ location.backend }};
 {% if location.custom_css is defined %}
         proxy_set_header Accept-Encoding "";
         sub_filter

--- a/templates/default.conf.j2
+++ b/templates/default.conf.j2
@@ -35,9 +35,11 @@ server {
 {% if location.extra_parameters is defined and location.extra_parameters != None %}
         {{ location.extra_parameters|indent(8, False) }}
 {% endif %}
+{# If location.proxy === True or a non-empty string, proxy the request #}
 {% if ((location.proxy | default(False) is sameas True)) or (location.proxy | default(False)) is string  %}
         include /etc/nginx/proxy.conf;
-        proxy_pass {{ (location.proxy is string and location.proxy) or 'http://' }}{{ location.backend }};
+        {# If location.proxy is a string, it is assumed to be a properly formatted scheme/protocol, if it is True then default to 'http://' #}
+        proxy_pass {{ (location.proxy is string) | ternary(location.proxy, 'http://') }}{{ location.backend }};
 {% if location.custom_css is defined %}
         proxy_set_header Accept-Encoding "";
         sub_filter

--- a/templates/default.conf.j2
+++ b/templates/default.conf.j2
@@ -35,7 +35,7 @@ server {
 {% if location.extra_parameters is defined and location.extra_parameters != None %}
         {{ location.extra_parameters|indent(8, False) }}
 {% endif %}
-{% if (location.proxy | default(False)) is truthy %}
+{% if (location.proxy | default(False)) is boolean or (location.proxy | default(False)) is string  %}
         include /etc/nginx/proxy.conf;
         proxy_pass {{ (location.proxy is string and location.proxy) or 'http://' }}{{ location.backend }};
 {% if location.custom_css is defined %}

--- a/templates/default.conf.j2
+++ b/templates/default.conf.j2
@@ -35,9 +35,9 @@ server {
 {% if location.extra_parameters is defined and location.extra_parameters != None %}
         {{ location.extra_parameters|indent(8, False) }}
 {% endif %}
-{% if location.proxy is defined and location.proxy %}
+{% if (location.proxy | default(False)) is truthy %}
         include /etc/nginx/proxy.conf;
-        proxy_pass {{ location.proxypass_protocol }}{{ location.backend }};
+        proxy_pass {{ (location.proxy is string and location.proxy) or 'http://' }}{{ location.backend }};
 {% if location.custom_css is defined %}
         proxy_set_header Accept-Encoding "";
         sub_filter

--- a/templates/default.conf.j2
+++ b/templates/default.conf.j2
@@ -35,7 +35,7 @@ server {
 {% if location.extra_parameters is defined and location.extra_parameters != None %}
         {{ location.extra_parameters|indent(8, False) }}
 {% endif %}
-{% if (location.proxy | default(False)) is boolean or (location.proxy | default(False)) is string  %}
+{% if ((location.proxy | default(False) is sameas True)) or (location.proxy | default(False)) is string  %}
         include /etc/nginx/proxy.conf;
         proxy_pass {{ (location.proxy is string and location.proxy) or 'http://' }}{{ location.backend }};
 {% if location.custom_css is defined %}


### PR DESCRIPTION
Combine the proxy flag and protocol into one variable for simplicity

If `proxy` is truthy (true,non-empty string) - it includes proxy.conf
If `proxy` is a boolean - default to `http://`
If `proxy is a string - use it